### PR TITLE
chore: initialize bottles for vscode formulas

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: bottles_${{ matrix.os }}
           path: '*.bottle.*'

--- a/Formula/vscode-html-languageservice.rb
+++ b/Formula/vscode-html-languageservice.rb
@@ -5,10 +5,6 @@ class VscodeHtmlLanguageservice < Formula
   sha256 "93e4e3b97c0af720ff5068187b7058ed9843c155cd47859db05ba53c12b38d78"
   license "MIT"
 
-  bottle do
-    sha256 cellar: :any_skip_relocation, all: "59cb4fd7006fbecfba8e923a6b88f993b7bd154135edf2142f101152fcbd2c2d"
-  end
-
   depends_on "node"
   conflicts_with "vscode-langservers-extracted", because: "both provide vscode-html-language-server"
 

--- a/Formula/vscode-langservers-extracted.rb
+++ b/Formula/vscode-langservers-extracted.rb
@@ -10,9 +10,6 @@ class VscodeLangserversExtracted < Formula
     formula "vscode-html-languageservice"
   end
 
-  bottle do
-    sha256 cellar: :any_skip_relocation, all: "15af5b99737600753a84dbfe8dcb22799af0d40959d6f79449811c2f543823d7"
-  end
 
   depends_on "huadeity/tap/vscode-html-languageservice"
   depends_on "node"

--- a/Formula/vscode-langservers-extracted.rb
+++ b/Formula/vscode-langservers-extracted.rb
@@ -10,7 +10,6 @@ class VscodeLangserversExtracted < Formula
     formula "vscode-html-languageservice"
   end
 
-
   depends_on "huadeity/tap/vscode-html-languageservice"
   depends_on "node"
 


### PR DESCRIPTION
Removes placeholder bottle blocks to trigger brew test-bot bottle build. After CI passes, apply `pr-pull` label to upload bottles to GHCR and merge.