### PR TITLE
fix: use libexec.glob for symlinks to produce all: bottles

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ macos-15-intel, macos-26 ]
+        os: [ macos-26 ]
         include:
           - os: ubuntu-latest
             container: ghcr.io/homebrew/brew:main

--- a/Formula/vscode-html-languageservice.rb
+++ b/Formula/vscode-html-languageservice.rb
@@ -17,7 +17,7 @@ class VscodeHtmlLanguageservice < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink libexec/"bin/vscode-html-language-server"
+    bin.install_symlink libexec.glob("bin/vscode-html-language-server")
   end
 
   test do

--- a/Formula/vscode-langservers-extracted.rb
+++ b/Formula/vscode-langservers-extracted.rb
@@ -22,10 +22,7 @@ class VscodeLangserversExtracted < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink libexec/"bin/vscode-css-language-server"
-    bin.install_symlink libexec/"bin/vscode-json-language-server"
-    bin.install_symlink libexec/"bin/vscode-eslint-language-server"
-    bin.install_symlink libexec/"bin/vscode-markdown-language-server"
+    bin.install_symlink libexec.glob("bin/vscode-{css,json,eslint,markdown}-language-server")
   end
 
   test do


### PR DESCRIPTION
Switches from `libexec/"bin/..."` (absolute symlinks) to `libexec.glob(...)` (relative symlinks) so Linux and macOS bottles produce identical content, allowing brew pr-pull to consolidate into a single `all:` SHA.

Same fix was applied upstream in homebrew-core for `vscode-langservers-extracted`.