### PR TITLE
fix: inreplace absolute node shebang for uniform all: bottle

### DIFF
--- a/Formula/vscode-html-languageservice.rb
+++ b/Formula/vscode-html-languageservice.rb
@@ -6,10 +6,7 @@ class VscodeHtmlLanguageservice < Formula
   license "MIT"
 
   bottle do
-    root_url "https://github.com/HuaDeity/homebrew-tap/releases/download/vscode-html-languageservice-4.10.7"
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:  "98d681e82bab27fa142ad9c909f438b7de5eeee684dce30e4609fe3fc7d2a7c9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "32c05879659299b704fda9672a16801163325f0fd9851f42a2324e9832432c3b"
+    root_url "https://ghcr.io/v2/huadeity/homebrew-tap"
   end
 
   depends_on "node"

--- a/Formula/vscode-langservers-extracted.rb
+++ b/Formula/vscode-langservers-extracted.rb
@@ -11,10 +11,7 @@ class VscodeLangserversExtracted < Formula
   end
 
   bottle do
-    root_url "https://github.com/HuaDeity/homebrew-tap/releases/download/vscode-langservers-extracted-4.10.7"
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:  "c36071b2eb557d1aa2b240285e9a15d852b826de58409bcc6771a732f73e5467"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ccdd7d0b4c2d71f6b5f45b3eea7ca8cd96759c406ea76af336f2f6f9ccaad552"
+    root_url "https://ghcr.io/v2/huadeity/homebrew-tap"
   end
 
   depends_on "huadeity/tap/vscode-html-languageservice"


### PR DESCRIPTION
npm writes the absolute node binary path (e.g. `/opt/homebrew/opt/node/bin/node` on macOS, `/home/linuxbrew/.linuxbrew/opt/node/bin/node` on Linux) into every installed script shebang, causing per-platform bottle SHAs.

Replace all shebangs with `/usr/bin/env node` so all platforms produce identical bottle content, allowing `brew pr-pull` to consolidate into a single `all:` SHA.

Root cause confirmed by inspecting the installed files locally.