### PR TITLE
vscode-html-languageservice, vscode-langservers-extracted: migrate bottles to GHCR

### DIFF
--- a/Formula/vscode-html-languageservice.rb
+++ b/Formula/vscode-html-languageservice.rb
@@ -6,10 +6,7 @@ class VscodeHtmlLanguageservice < Formula
   license "MIT"
 
   bottle do
-    root_url "https://github.com/HuaDeity/homebrew-tap/releases/download/vscode-html-languageservice-4.10.7"
-    rebuild 3
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "36c9accb24cd2205c5f8e472cc7d0ece4b16c3d910f47d5cb14e340944da6a38"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a633e13e816aa82b6e06c8601e602f63ded1119204163e6605b63478d59956c4"
+    root_url "https://ghcr.io/v2/huadeity/homebrew-tap"
   end
 
   depends_on "node"

--- a/Formula/vscode-langservers-extracted.rb
+++ b/Formula/vscode-langservers-extracted.rb
@@ -11,10 +11,7 @@ class VscodeLangserversExtracted < Formula
   end
 
   bottle do
-    root_url "https://github.com/HuaDeity/homebrew-tap/releases/download/vscode-langservers-extracted-4.10.7"
-    rebuild 3
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0ef1000e43b2bdd00daa83d24c4630ce8e8399a2a19ea16695c47907530e90db"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d3c23a6eb42f4d2b392c2aba7727d4b20fe6dedb4d93e5f2c0b42f36a1030597"
+    root_url "https://ghcr.io/v2/huadeity/homebrew-tap"
   end
 
   depends_on "huadeity/tap/vscode-html-languageservice"


### PR DESCRIPTION
Migrate bottle hosting from GitHub Releases to GHCR. Built with --only-json-tab for reproducible all: bottles.