### PR TITLE
vscode-html-languageservice, vscode-langservers-extracted: rebuild bottles on GHCR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,18 @@ jobs:
           bottles-directory: ${{ env.BOTTLES_DIR }}
 
       - name: Test formulae
-        run: brew test-bot --only-formulae --only-json-tab
+        # --only-json-tab: removes INSTALL_RECEIPT.json before tarring and uses GNU tar for
+        # reproducibility. Without it, INSTALL_RECEIPT.json differs per platform (OS, arch,
+        # compiler, dependency versions), making each platform's bottle SHA unique and
+        # preventing brew bottle --merge from consolidating them into a single `all:` bottle.
+        # With it, all platforms produce identical tarballs → identical SHAs → `all:` bottle.
+        #
+        # --root-url: brew test-bot defaults to GitHub Releases URL for non-core taps
+        # (see test_bot/formulae.rb). This URL ends up in the bottle JSON, and brew bottle
+        # --merge reads root_url directly from the JSON (ignoring brew pr-pull's --root-url).
+        # Passing it here ensures the JSON — and therefore the formula — gets the correct
+        # GHCR root_url.
+        run: brew test-bot --only-formulae --only-json-tab --root-url="https://ghcr.io/v2/huadeity/homebrew-tap"
         working-directory: ${{ env.BOTTLES_DIR }}
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Formula/vscode-html-languageservice.rb
+++ b/Formula/vscode-html-languageservice.rb
@@ -5,12 +5,6 @@ class VscodeHtmlLanguageservice < Formula
   sha256 "93e4e3b97c0af720ff5068187b7058ed9843c155cd47859db05ba53c12b38d78"
   license "MIT"
 
-  bottle do
-    root_url "https://github.com/HuaDeity/homebrew-tap/releases/download/vscode-html-languageservice-4.10.7"
-    rebuild 4
-    sha256 cellar: :any_skip_relocation, all: "99c52e3b988220c61358ac05685cea3e1a9a38262ca5e0d2ba2f7fab651f1ced"
-  end
-
   depends_on "node"
   conflicts_with "vscode-langservers-extracted", because: "both provide vscode-html-language-server"
 

--- a/Formula/vscode-langservers-extracted.rb
+++ b/Formula/vscode-langservers-extracted.rb
@@ -10,12 +10,6 @@ class VscodeLangserversExtracted < Formula
     formula "vscode-html-languageservice"
   end
 
-  bottle do
-    root_url "https://github.com/HuaDeity/homebrew-tap/releases/download/vscode-langservers-extracted-4.10.7"
-    rebuild 4
-    sha256 cellar: :any_skip_relocation, all: "9e3a38394b76434f551d08f04bf1d4d92542ffbbe8ffea01c4cabca752e86e79"
-  end
-
   depends_on "huadeity/tap/vscode-html-languageservice"
   depends_on "node"
 


### PR DESCRIPTION
## Summary

- Strip stale bottle blocks from both formulas — CI will add them fresh with no rebuild counter
- Fix `tests.yml`: pass `--root-url` to `brew test-bot` so the bottle JSON (and therefore the formula) gets the correct GHCR `root_url` instead of the GitHub Releases fallback
- Add comments explaining why `--only-json-tab` and `--root-url` are both needed

## Root cause of previous wrong `root_url`

`brew test-bot` in `test_bot/formulae.rb` hardcodes a GitHub Releases `root_url` for non-core taps when no `--root-url` is passed. That URL ends up in the bottle JSON. `brew bottle --merge` then reads `root_url` directly from the JSON — it ignores `brew pr-pull`'s `--root-url` flag. Passing `--root-url` to `brew test-bot` is the correct fix.

## Test plan

- [ ] CI builds `all:` bottles with `root_url "https://ghcr.io/v2/huadeity/homebrew-tap"` and no `rebuild` counter
- [ ] Label `pr-pull` to publish