### PR TITLE
vscode-html-languageservice, vscode-langservers-extracted: add formulae

### DIFF
--- a/Formula/vscode-html-languageservice.rb
+++ b/Formula/vscode-html-languageservice.rb
@@ -1,0 +1,37 @@
+class VscodeHtmlLanguageservice < Formula
+  desc "HTML language server with Zed's workspace-edit tag rename patch"
+  homepage "https://github.com/zed-industries/vscode-langservers-extracted"
+  url "https://registry.npmjs.org/@zed-industries/vscode-langservers-extracted/-/vscode-langservers-extracted-4.10.7.tgz"
+  sha256 "93e4e3b97c0af720ff5068187b7058ed9843c155cd47859db05ba53c12b38d78"
+  license "MIT"
+
+  depends_on "node"
+  conflicts_with "vscode-langservers-extracted", because: "both provide vscode-html-language-server"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/vscode-html-language-server")
+  end
+
+  test do
+    require "open3"
+
+    json = <<~JSON
+      {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+          "rootUri": null,
+          "capabilities": {}
+        }
+      }
+    JSON
+
+    Open3.popen3("#{bin}/vscode-html-language-server", "--stdio") do |stdin, stdout|
+      stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
+      sleep 3
+      assert_match(/^Content-Length: \d+/i, stdout.readline)
+    end
+  end
+end

--- a/Formula/vscode-langservers-extracted.rb
+++ b/Formula/vscode-langservers-extracted.rb
@@ -1,0 +1,44 @@
+class VscodeLangserversExtracted < Formula
+  desc "HTML/CSS/JSON/ESLint/Markdown language servers with Zed's patched HTML server"
+  homepage "https://github.com/zed-industries/vscode-langservers-extracted"
+  url "https://registry.npmjs.org/vscode-langservers-extracted/-/vscode-langservers-extracted-4.10.0.tgz"
+  version "4.10.7"
+  sha256 "d6e2d090d09c4b91daa74e9e7462a3d3f244efb96aa5111004cfffa49d6dc9ef"
+  license "MIT"
+
+  livecheck do
+    formula "vscode-html-languageservice"
+  end
+
+  depends_on "huadeity/tap/vscode-html-languageservice"
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/vscode-{css,json,eslint,markdown}-language-server")
+  end
+
+  test do
+    require "open3"
+
+    json = <<~JSON
+      {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+          "rootUri": null,
+          "capabilities": {}
+        }
+      }
+    JSON
+
+    %w[css eslint json markdown].each do |lang|
+      Open3.popen3("#{bin}/vscode-#{lang}-language-server", "--stdio") do |stdin, stdout|
+        stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
+        sleep 3
+        assert_match(/^Content-Length: \d+/i, stdout.readline)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Re-adding formulae as new to reset the bottle rebuild counter to 0 (no `rebuild` line).

Since `brew bottle` computes the rebuild counter as `origin/HEAD_rebuild + 1`, and these formulae no longer exist at `origin/HEAD`, the counter resolves to `nil || 0 = 0` — producing clean bottles with no rebuild line.