### PR TITLE
package-version-server 0.0.10 (new formula)

### DIFF
--- a/Formula/package-version-server.rb
+++ b/Formula/package-version-server.rb
@@ -1,0 +1,44 @@
+class PackageVersionServer < Formula
+  desc "Language server that handles hover information in package.json files"
+  homepage "https://github.com/zed-industries/package-version-server"
+  url "https://github.com/zed-industries/package-version-server/archive/refs/tags/v0.0.10.tar.gz"
+  sha256 "0ea78ae53981223fcad9eed35cf0f0e4a9f70619dafcff358d2efe11ab1b641d"
+  license "MIT"
+  head "https://github.com/zed-industries/package-version-server.git", branch: "main"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match "package-version-server #{version}",
+                 shell_output("#{bin}/package-version-server --version")
+
+    require "open3"
+
+    json = <<~JSON
+      {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+          "rootUri": null,
+          "capabilities": {}
+        }
+      }
+    JSON
+
+    Open3.popen3(bin/"package-version-server") do |stdin, stdout|
+      stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
+      sleep 1
+      assert_match(/^Content-Length: \d+/i, stdout.readline)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- New formula for [zed-industries/package-version-server](https://github.com/zed-industries/package-version-server) v0.0.10 — language server providing hover info for `package.json` dependency keys.
- Uses `cargo install` with the `rust` build dependency. Reqwest's default-tls relies on Security.framework on macOS (no extra deps needed); we'll re-introduce `pkg-config`/`openssl@3` if/when Linux support is added back.
- Test exercises `--version` and a real LSP `initialize` handshake over stdio.

## Test plan
- [x] `brew style Formula/package-version-server.rb` clean
- [x] `brew audit --new --strict --formula huadeity/tap/package-version-server` clean
- [x] `brew install --build-from-source huadeity/tap/package-version-server` succeeds locally on arm64 macOS
- [x] `brew test huadeity/tap/package-version-server` passes
- [ ] CI green on macos-latest + ubuntu-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)