### PR TITLE
vscode-langservers-extracted-zed: align test with homebrew-core

### DIFF
--- a/Formula/vscode-langservers-extracted-zed.rb
+++ b/Formula/vscode-langservers-extracted-zed.rb
@@ -41,13 +41,13 @@ class VscodeLangserversExtractedZed < Formula
       }
     JSON
 
-    # The markdown server crashes on startup under Node 26 due to an upstream
+    # html is provided by the vscode-html-languageservice dependency, not this
+    # formula. markdown crashes on startup under Node 26 due to an upstream
     # ESM/CJS interop bug in vscode-markdown-languageservice (vscode-uri default
     # import), so it cannot respond to the LSP handshake.
     %w[css eslint json].each do |lang|
       Open3.popen3("#{bin}/vscode-#{lang}-language-server", "--stdio") do |stdin, stdout|
         stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
-        stdin.flush
         sleep 3
         assert_match(/^Content-Length: \d+/i, stdout.readline)
       end


### PR DESCRIPTION
Follow-up cleanup to PR #113 (which merged the actual CI fix).

Removes the superfluous `stdin.flush` from the test — it is not present in homebrew-core's test and was verified to have no effect on the LSP handshake (css/eslint/json pass with or without it; markdown crashes either way due to the upstream Node 26 ESM bug). Also notes in the comment that the html server comes from the `vscode-html-languageservice` dependency rather than this formula.

Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)