### PR TITLE
Drop formula_renames.json

### DIFF
--- a/formula_renames.json
+++ b/formula_renames.json
@@ -1,3 +1,0 @@
-{
-  "vscode-langservers-extracted": "vscode-langservers-extracted-zed"
-}


### PR DESCRIPTION
`formula_renames.json` mapped the homebrew-core formula name `vscode-langservers-extracted` to this tap's `vscode-langservers-extracted-zed`, which hijacks references to the official formula and causes a conflict.

Removing the rename. The `conflicts_with "vscode-langservers-extracted"` declaration in the formula already prevents both from being installed simultaneously, so no migration mapping is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)